### PR TITLE
Socket events general fixes

### DIFF
--- a/backend/src/constants/relayChat.ts
+++ b/backend/src/constants/relayChat.ts
@@ -18,6 +18,8 @@ export const ERROR = {
   ERROR_PASSWORD_FORMAT: "Invalid password format",
   // Chat Error messages
   ERROR_CHAT_NOT_FOUND: "Chat not found",
+  ERROR_SOCKET_INSTANCE_NOT_FOUND:
+    "We could find the socket instance based on the socket id you provided",
   // General Error messages
   ERROR_EMAIL_PASSWORD_MISSING: "Either the Password or Email wasn't provided",
   ERROR_ID_REQUIRED: "ID was not provided",

--- a/backend/src/controllers/chatController.ts
+++ b/backend/src/controllers/chatController.ts
@@ -48,8 +48,8 @@ export const getChatsByUserId = async (
         chatPic: chat.chatPic,
         lastMessage: lastMessage
           ? {
-              content: lastMessage.message,
-              sender: lastMessage.author,
+              message: lastMessage.message,
+              author: lastMessage.author,
               timestamp: lastMessage.createdAt,
             }
           : null,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,29 +8,17 @@ import { errorMiddleware } from "@/middlewares/errorMiddleware";
 import { handleSocketEvents } from "@/sockets/chatSocket";
 const app: Express = express();
 const server = createServer(app);
-// Initialize socket
-const io = new Server(server);
 const PORT: number = 3001;
 
 // Define a CORS options object
 const corsOptions = {
-  origin: (
-    origin: string | undefined,
-    callback: (err: Error | null, allow?: boolean) => void
-  ) => {
-    const allowedOrigins = ["http://localhost:5173"];
-
-    if (allowedOrigins.indexOf(origin as string) !== -1 || !origin) {
-      // If the origin is in the allowedOrigins list or there's no origin (like from a same-origin request), allow it
-      callback(null, true);
-    } else {
-      // If the origin is not in the allowed list, block it
-      callback(new Error("Not allowed by CORS"), false);
-    }
-  },
-  methods: ["GET", "POST", "PUT", "DELETE"], // List allowed HTTP methods
-  allowedHeaders: ["Content-Type", "Authorization"], // Allowed headers
+  origin: "http://localhost:5173", // Allow requests from your client origin
+  methods: ["GET", "POST", "PUT", "DELETE"], // Specify allowed HTTP methods
+  headers: ["Content-Type", "Authorization"], // Specify allowed headers
 };
+
+// Initialize socket
+const io = new Server(server, { cors: corsOptions });
 
 app.use(cors(corsOptions));
 

--- a/backend/src/interfaces/chat.ts
+++ b/backend/src/interfaces/chat.ts
@@ -1,6 +1,7 @@
 import { Types, Document } from "mongoose";
 import { IUser } from "@/interfaces/user";
 import { IMessageDocument } from "@/interfaces/message";
+import { IPendingInvites } from "./pendingChatInvites";
 
 export interface IChat {
   chatPic: string;
@@ -21,12 +22,15 @@ export interface IChatService {
   saveChat(
     chatName: string,
     type: "direct" | "group",
-    userId: string
+    membersIds: string[]
   ): Promise<IChatDocument>;
   saveMessage(
     chatId: string,
     message: string,
     userId: string
   ): Promise<IMessageDocument>;
+  getPendingChatInvitesByUserId(userId: string): Promise<IPendingInvites[]>;
+  saveChatInvitation(userId: string, chatName: string): Promise<void>;
+  clearPendingChatInvites(userId: string): Promise<void>;
   handleDisconnect(userId: string, user: Partial<IUser>): Promise<IUser | null>;
 }

--- a/backend/src/interfaces/pendingChatInvites.ts
+++ b/backend/src/interfaces/pendingChatInvites.ts
@@ -1,0 +1,8 @@
+import { Document, Types } from "mongoose";
+
+export interface IPendingInvites {
+  userId: Types.ObjectId;
+  chatName: string;
+}
+
+export interface IPendingInvitesDocument extends IPendingInvites, Document {}

--- a/backend/src/models/pendingChatInvites.ts
+++ b/backend/src/models/pendingChatInvites.ts
@@ -1,0 +1,22 @@
+import { IPendingInvitesDocument } from "@/interfaces/pendingChatInvites";
+import { Schema, model } from "mongoose";
+
+const pendingChatSchema = new Schema<IPendingInvitesDocument>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      unique: true,
+    },
+    chatName: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+const PendingChatInvites = model<IPendingInvitesDocument>(
+  "PendingChatInvites",
+  pendingChatSchema
+);
+
+export default PendingChatInvites;

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -7,15 +7,20 @@ export default class UserService implements IUserService {
   }
 
   async getUserByEmail(email: string): Promise<IUserDocument | null> {
-    return await User.findOne({email}).exec();
+    return await User.findOne({ email }).exec();
   }
 
   async getUserByUsername(username: string): Promise<IUser | null> {
-    return await User.findOne({username}).exec();
+    return await User.findOne({ username }).exec();
   }
 
   async getUserBySocketId(socketId: string): Promise<IUserDocument | null> {
-    return await User.findOne({socketId}).exec();
+    return await User.findOne({ socketId }).exec();
+  }
+
+  async getUserSocketIdByUserId(userId: string): Promise<string | null> {
+    const user = await User.findOne({ id: userId }).exec();
+    return user ? user.socketId : null;
   }
 
   async createUser(user: IUser): Promise<IUser> {
@@ -23,7 +28,10 @@ export default class UserService implements IUserService {
     return await newUser.save();
   }
 
-  async updateUser(id: string, updatedUser: Partial<IUser>): Promise<IUser | null> {
+  async updateUser(
+    id: string,
+    updatedUser: Partial<IUser>
+  ): Promise<IUser | null> {
     return await User.findByIdAndUpdate(
       id,
       { ...updatedUser, updatedAt: new Date().toISOString() },

--- a/backend/src/sockets/chatSocket.ts
+++ b/backend/src/sockets/chatSocket.ts
@@ -1,16 +1,37 @@
 import { Server, Socket } from "socket.io";
 import * as chatController from "@/controllers/chatController";
+import { assignSocketIdByUserId } from "@/controllers/userController";
 import { ErrorHandler } from "@/utils/errorHandler";
 import { ERROR } from "@/constants/relayChat";
 import { StatusCodes } from "http-status-codes";
 
 export const handleSocketEvents = (io: Server, socket: Socket) => {
+  /**
+   * Initiate socket connection and assign socket.id to the user
+     and look up for pending chats invites
+   */
+  socket.on("initiateSocket", async (userId: string) => {
+    await assignSocketIdByUserId(userId, socket);
+  });
+
   // Handle 'joinChat' event
   socket.on(
     "joinChat",
-    async (chatName: string, type: "direct" | "group", userId: string) => {
+    async (
+      chatName: string,
+      type: "direct" | "group",
+      currentUserId: string,
+      membersIds: string[]
+    ) => {
       try {
-        await chatController.joinChat(io, socket, chatName, type, userId); // Call your controller's joinChat logic
+        await chatController.joinChat(
+          io,
+          socket,
+          chatName,
+          type,
+          currentUserId,
+          membersIds
+        );
       } catch (error: unknown) {
         // Handle errors by emitting the error message to the client
         if (error instanceof ErrorHandler) {


### PR DESCRIPTION
This PR includes:

- A new event, "initiateSocket," which assigns the socket.id to the user based on their user ID.
- A new method to look up "Pending Chat Invites" when a user reconnects (for offline users).
- A modification to the "joinChat" event to accept a set of parameters: `{
  chatName: "Test",
  type: "group",
  currentUserId: "some_id",
  membersIds: ["array of user ids"]
}` This will proceed to "invite" users/contacts to join the chat.
- A method that cleans/removes all "Pending Chat Invites" once the user has joined all of them.